### PR TITLE
update to latest mruby

### DIFF
--- a/src/ffi.c
+++ b/src/ffi.c
@@ -14,7 +14,7 @@ static mrb_value longsize(mrb_state *mrb, mrb_value self)
 void mrb_mruby_rubyffi_compat_gem_init(mrb_state *mrb)
 {
   struct RClass *mod = mrb_define_module(mrb, "FFI");
-  mrb_define_class_method(mrb, mod, "longsize", longsize, ARGS_NONE());
+  mrb_define_class_method(mrb, mod, "longsize", longsize, MRB_ARGS_NONE());
 }
 
 void mrb_mruby_rubyffi_compat_gem_final(mrb_state *mrb)


### PR DESCRIPTION
but, your dependency mrbgem, mruby-cfunc on HEAD is not buildable.
I can't check it, I suppose it works well. 