### PR TITLE
Add Missing :float In lib/types.rb

### DIFF
--- a/mrblib/lib/types.rb
+++ b/mrblib/lib/types.rb
@@ -25,6 +25,7 @@ module FFI
     :string   => CFunc::Pointer,
     :pointer  => CFunc::Pointer,
     :void     => CFunc::Void,
+    :float    => CFunc::Float,
     :double   => CFunc::Double,
     :size_t   => CFunc::UInt32,
     :ulong    => (FFI.longsize == 8) ? CFunc::UInt64 : CFunc::UInt32,


### PR DESCRIPTION
It looks like a symbol for float arguments or return values was missing. Adding it in seems to work on my system.